### PR TITLE
Update transfer in query to use line item reason for identifier

### DIFF
--- a/src/main/java/org/openlmis/integration/dhis2/repository/indicator/StockAdjustmentsAndTransfersRepository.java
+++ b/src/main/java/org/openlmis/integration/dhis2/repository/indicator/StockAdjustmentsAndTransfersRepository.java
@@ -227,7 +227,7 @@ public class StockAdjustmentsAndTransfersRepository {
             + "JOIN referencedata.orderables products ON products.id = cards.orderableid "
             + "JOIN referencedata.facilities as facilities "
             + "on facilities.id = cards.facilityid "
-            + "WHERE line_items.sourceid is not null "
+            + "WHERE reasons.name = 'Transfer In' "
             + "AND line_items.occurreddate >= :startDate "
             + "AND line_items.occurreddate < :endDate "
             + "AND products.code ILIKE :orderable "


### PR DESCRIPTION
This feature updates the query used to calculate the transfer-in indicator